### PR TITLE
Fixed the database filepath

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,14 +3,6 @@ import os
 basedir = os.path.abspath(os.path.dirname(__file__))
 
 class Config:
-    SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(basedir, 'app.db')
-    SQLALCHEMY_TRACK_MODIFICATIONS = False
-
-
-import os
-
-class Config:
     SECRET_KEY = os.environ.get("SECRET_KEY", "fallback-secret-key")
-    SQLALCHEMY_DATABASE_URI = os.environ.get("DATABASE_URL", "sqlite:///app.db")
+    SQLALCHEMY_DATABASE_URI = os.environ.get("DATABASE_URL", "sqlite:///" + os.path.join(basedir, "app.db"))
     SQLALCHEMY_TRACK_MODIFICATIONS = False
-


### PR DESCRIPTION
The database for the app was being created in a new filepath inside an instance directory. This caused the previous database on my computer to be ignored.

This was happening due to two config classes being created in the config.py file instead of one,
Merging the two classes fixed the issues