### PR TITLE
Book status in newsfeed is changed to titlecase from lowercase

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -316,7 +316,7 @@ def community_feed():
         feed.append({
             'title': book.title,
             'cover_url': book.cover_url,
-            'status': share.status,
+            'status': share.status.title(),
             'from_username': share.from_user.username,
             'to_username': share.to_user.username,
             'timestamp': share.timestamp.strftime('%Y-%m-%d %H:%M'),


### PR DESCRIPTION
Changelog:
- Updated routes.py to pass the titlecased status of a book from the database to the frontend