### PR TITLE
Fixed the API used section of the FAQ in the homepage

### DIFF
--- a/app/templates/homepage.html
+++ b/app/templates/homepage.html
@@ -147,7 +147,7 @@
                 <div id="collapseTwo" class="accordion-collapse collapse" aria-labelledby="headingTwo"
                     data-bs-parent="#faqAccordion">
                     <div class="accordion-body">
-                        You can browse and search books, but to save and track your own, you’ll need an account.
+                        You can browse and search for books, but to save and keep track of your own books, you will need an account.
                     </div>
                 </div>
             </div>
@@ -162,7 +162,7 @@
                 <div id="collapseThree" class="accordion-collapse collapse" aria-labelledby="headingThree"
                     data-bs-parent="#faqAccordion">
                     <div class="accordion-body">
-                        BookTracker uses the Open Library API to fetch book information in real time.
+                        BookTracker uses the Google Books API to fetch book information in real time.
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Changelog:
- Changed the homepage faq section to say Google Books API instead of Open Library API
- Updated the second answer to be clearer